### PR TITLE
Add logo href to Fern docs config

### DIFF
--- a/fern/api/docs/docs.yml
+++ b/fern/api/docs/docs.yml
@@ -4,4 +4,6 @@ colors:
   accentPrimary: "#75f96f"
 title: Hathora | API Docs
 favicon: ./favicon.ico
-logo: ./logo.png
+logo:
+  path: ./logo.png
+  href: https://hathora.dev

--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "hathora",
-  "version": "0.11.3-rc9"
+  "version": "0.11.4-rc0"
 }


### PR DESCRIPTION
Adds logo `href` which allows linking the header logo to a specified URL. 